### PR TITLE
Add a confirmation popup before deleting

### DIFF
--- a/classes/tables/entries_table.php
+++ b/classes/tables/entries_table.php
@@ -20,6 +20,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir.'/tablelib.php');
 
+use action_link;
 use action_menu;
 use moodle_url;
 use renderer_base;
@@ -78,7 +79,10 @@ class entries_table extends table_sql {
         // The pix_icons use default moodle icons.
         $menu = new action_menu();
         $menu->add(new \action_menu_link_primary($updateurl, new \pix_icon('i/edit', $editstr), $editstr));
-        $menu->add(new \action_menu_link_primary($deleteurl, new \pix_icon('i/delete', $deletestr), $deletestr));
+
+        $deleteaction = new \confirm_action(get_string('confirmdelete', 'mod_cpdlogbook', $record->name));
+        $delete = new action_link($deleteurl, '', $deleteaction, [], new \pix_icon('i/delete', $deletestr));
+        $menu->add_primary_action($delete);
 
         return $this->output->render($menu);
     }

--- a/lang/en/cpdlogbook.php
+++ b/lang/en/cpdlogbook.php
@@ -23,3 +23,4 @@ $string['name'] = 'Name';
 $string['points'] = 'Points';
 $string['entryname'] = 'Name';
 $string['createtitle'] = 'Create a new entry';
+$string['confirmdelete'] = 'Are you sure you want to delete entry "{$a}"?';


### PR DESCRIPTION
This resolves #18. The user is asked to confirm the delete action before the record is deleted. The action name is displayed in the confirmation box.
This is being merged into the `cmid_security` branch since both make changes to the `delete` action, and this avoids the merge conflicts.