### PR TITLE
Add `mod/cpdlogbook:edit` capability

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -37,5 +37,16 @@ $capabilities = [
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW
         ]
+    ],
+
+    'mod/cpdlogbook:edit' => [
+        'riskbitmask' => RISK_DATALOSS | RISK_PERSONAL,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'student' => CAP_ALLOW,
+        ]
     ]
 ];

--- a/edit.php
+++ b/edit.php
@@ -48,6 +48,8 @@ if ($create) {
 
 $context = context_module::instance($cm->id);
 
+require_capability('mod/cpdlogbook:edit', $context);
+
 $mform = new edit_entry();
 
 if ($mform->is_cancelled()) {


### PR DESCRIPTION
The user is required to have this capability before they can access `edit.php`.
By default, managers, editing teachers, and students have this capability.
Resolves #43