### PR TITLE
Add moodlecheck (PHPdoc check) to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,6 @@ jobs:
         if: matrix.moodle-branch == 'MOODLE_39_STABLE'
         run: moodle-plugin-ci codechecker
 
-      - name: Run moodlecheck
-        if: matrix.moodle-branch == 'MOODLE_39_STABLE'
-        run: moodle-plugin-ci moodlecheck
-
       - name: Run validate
         if: ${{ always() }}
         run: moodle-plugin-ci validate
@@ -120,9 +116,9 @@ jobs:
         run: moodle-plugin-ci grunt
 
       # PHPDoc works but needs a *LOT* of love
-      #- name: Run phpdoc
-      #  if: ${{ always() }}
-      #  run: moodle-plugin-ci phpdoc
+      - name: Run phpdoc
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
 
       - name: Run phpunit
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,10 @@ jobs:
         if: matrix.moodle-branch == 'MOODLE_39_STABLE'
         run: moodle-plugin-ci codechecker
 
+      - name: Run moodlecheck
+        if: matrix.moodle-branch == 'MOODLE_39_STABLE'
+        run: moodle-plugin-ci moodlecheck
+
       - name: Run validate
         if: ${{ always() }}
         run: moodle-plugin-ci validate


### PR DESCRIPTION
A possible fix for #68.
On Moodle, codechecker doesn't check the PHPdoc comments. The Moodle PHPdoc check plugin is used to do this.
Hopefully this change to the workflow/actions will check documentation as well.