### PR TITLE
Table headings now use lang strings.

### DIFF
--- a/classes/tables/entries_table.php
+++ b/classes/tables/entries_table.php
@@ -91,7 +91,28 @@ class entries_table extends table_sql {
         $this->column_style('hours',    'text-wrap', 'none');
         $this->collapsible(false);
 
-        $headers = $columns;
+        $headers = [
+            get_string('points', 'mod_cpdlogbook'),
+            get_string('name', 'mod_cpdlogbook'),
+            get_string('duration', 'mod_cpdlogbook'),
+            get_string('provider', 'mod_cpdlogbook'),
+            get_string('location', 'mod_cpdlogbook'),
+            get_string('date'),
+            get_string('actions'),
+        ];
+
+        if ($download) {
+            $headers = [
+                get_string('points', 'mod_cpdlogbook'),
+                get_string('name', 'mod_cpdlogbook'),
+                get_string('summary', 'mod_cpdlogbook'),
+                get_string('duration', 'mod_cpdlogbook'),
+                get_string('provider', 'mod_cpdlogbook'),
+                get_string('location', 'mod_cpdlogbook'),
+                get_string('date'),
+            ];
+        }
+
         $this->define_headers($headers);
         $this->show_download_buttons_at([TABLE_P_BOTTOM]);
 

--- a/details.php
+++ b/details.php
@@ -66,13 +66,13 @@ if (has_capability('mod/cpdlogbook:edit', $context)) {
 }
 
 echo html_writer::alist([
-    'Name: '.$record->name,
-    'Time: '.$record->time,
-    'Points: '.$record->points,
-    'Hours: '.$record->hours,
-    'Summary: '.$record->summary,
-    'Provider: '.$record->provider,
-    'Location: '.$record->location,
+    get_string('name', 'mod_cpdlogbook').': '.$record->name,
+    get_string('date').': '.userdate($record->time, get_string('summarydate', 'mod_cpdlogbook')),
+    get_string('points', 'mod_cpdlogbook').': '.$record->points,
+    get_string('duration', 'mod_cpdlogbook').': '.format_time($record->hours),
+    get_string('summary', 'mod_cpdlogbook').': '.$record->summary,
+    get_string('provider', 'mod_cpdlogbook').': '.$record->provider,
+    get_string('location', 'mod_cpdlogbook').': '.$record->location,
 ]);
 
 echo $OUTPUT->footer();


### PR DESCRIPTION
Table headings when viewing logbook entries now use language strings instead of hard-coded values.
This resolves #49