### PR TITLE
Persistent class used for update, create, and delete.

### DIFF
--- a/classes/persistent/period.php
+++ b/classes/persistent/period.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The mod_cpdlogbook persistent period class..
+ *
+ * @package mod_cpdlogbook
+ * @copyright 2021 Jordan Shatte <jsha773@hotmail.com>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_cpdlogbook\persistent;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Class period
+ *
+ * @package mod_cpdlogbook
+ */
+class period extends \core\persistent {
+
+    /**
+     * Table name for the persistent.
+     */
+    const TABLE = 'cpdlogbook_periods';
+
+    /**
+     * Defines the database fields for the period object.
+     *
+     * @return array[]
+     */
+    protected static function define_properties() {
+        return [
+            'startdate' => [
+                'type' => PARAM_INT,
+            ],
+            'enddate' => [
+                'type' => PARAM_INT,
+            ],
+            'cpdlogbookid' => [
+                'type' => PARAM_INT,
+            ]
+        ];
+    }
+
+}

--- a/classes/persistent/period.php
+++ b/classes/persistent/period.php
@@ -57,4 +57,29 @@ class period extends \core\persistent {
         ];
     }
 
+    /**
+     * Validate the start date.
+     *
+     * @param int $value
+     * @return bool
+     * @throws \coding_exception
+     */
+    protected function validate_startdate($value) {
+        $enddate = $this->raw_get('enddate');
+
+        return $value < $enddate;
+    }
+
+    /**
+     * Validate the end date.
+     *
+     * @param int $value
+     * @return bool
+     * @throws \coding_exception
+     */
+    protected function validate_enddate($value) {
+        $startdate = $this->raw_get('startdate');
+
+        return $startdate < $value;
+    }
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/cpdlogbook/db" VERSION="20210903" COMMENT="XMLDB file for Moodle mod/cpdlogbook"
+<XMLDB PATH="mod/cpdlogbook/db" VERSION="20210908" COMMENT="XMLDB file for Moodle mod/cpdlogbook"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -47,6 +47,9 @@
         <FIELD NAME="startdate" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="enddate" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="cpdlogbookid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -130,5 +130,36 @@ function xmldb_cpdlogbook_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2021080307, 'cpdlogbook');
     }
 
+    if ($oldversion < 2021080308) {
+
+        // Define field usermodified to be added to cpdlogbook_periods.
+        $table = new xmldb_table('cpdlogbook_periods');
+        $field = new xmldb_field('usermodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0', 'cpdlogbookid');
+
+        // Conditionally launch add field usermodified.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field timecreated to be added to cpdlogbook_periods.
+        $field = new xmldb_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0', 'usermodified');
+
+        // Conditionally launch add field timecreated.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field timemodified to be added to cpdlogbook_periods.
+        $field = new xmldb_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0', 'timecreated');
+
+        // Conditionally launch add field timemodified.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Cpdlogbook savepoint reached.
+        upgrade_mod_savepoint(true, 2021080308, 'cpdlogbook');
+    }
+
     return true;
 }

--- a/delete.php
+++ b/delete.php
@@ -22,6 +22,8 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use mod_cpdlogbook\persistent\period;
+
 require_once('../../config.php');
 
 $id = required_param('id', PARAM_INT);
@@ -29,10 +31,10 @@ $type = optional_param('type', 'entry', PARAM_TEXT);
 
 if ($type == 'period') {
     // If the entry doesn't exist.
-    $record = $DB->get_record('cpdlogbook_periods', ['id' => $id], '*', MUST_EXIST);
+    $period = new period($id);
 
     // If the cpdlogbook doesn't exist.
-    $cpdlogbook = $DB->get_record('cpdlogbook', ['id' => $record->cpdlogbookid], '*', MUST_EXIST);
+    $cpdlogbook = $DB->get_record('cpdlogbook', ['id' => $period->get('cpdlogbookid')], '*', MUST_EXIST);
 
     // Get the course module from the cpdlogbook instance.
     $cm = get_coursemodule_from_instance('cpdlogbook', $cpdlogbook->id, $cpdlogbook->course);
@@ -43,7 +45,7 @@ if ($type == 'period') {
     require_sesskey();
 
     // From here, we can be sure that the entry exists, and is associated with the current user and the cpdlogbook.
-    $DB->delete_records('cpdlogbook_periods', ['id' => $id, 'cpdlogbookid' => $cpdlogbook->id]);
+    $period->delete();
 
     redirect(new moodle_url('/mod/cpdlogbook/periods.php', ['id' => $cm->id]));
 } else {

--- a/version.php
+++ b/version.php
@@ -25,4 +25,4 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_cpdlogbook';
-$plugin->version = 2021080307;
+$plugin->version = 2021080308;


### PR DESCRIPTION
Replaces `$DB` usage to create, update, and delete periods with a persistent period class.
The periods table still uses tablelib, so the persistent class can't be used there.